### PR TITLE
Consistent jQuery object check

### DIFF
--- a/colorful/static/colorful/jQuery.colorPicker.js
+++ b/colorful/static/colorful/jQuery.colorPicker.js
@@ -159,4 +159,4 @@
   $.fn.colorPicker.defaultColors = 
   [ '000000', '993300','333300', '000080', '333399', '333333', '800000', 'FF6600', '808000', '008000', '008080', '0000FF', '666699', '808080', 'FF0000', 'FF9900', '99CC00', '339966', '33CCCC', '3366FF', '800080', '999999', 'FF00FF', 'FFCC00', 'FFFF00', '00FF00', '00FFFF', '00CCFF', '993366', 'C0C0C0', 'FF99CC', 'FFCC99', 'FFFF99' , 'CCFFFF', '99CCFF', 'FFFFFF'];
   
-})(jQuery || django.jQuery);
+})('django' in window ? django.jQuery : jQuery);


### PR DESCRIPTION
There is a bug that leads to improper jQuery object extending.

If some other admin widget appends jQuery object to a page then it is extended with colorPicker method. But in widget script still Django's own jQuery object is used that doen't get colorPicker method. So we need to make jQuery object check consistent in both cases.

PS: I encountered this bug trying to use your widget with django-image-cropping widget.
