### PR TITLE
Fix to improve compatibility with django-parsley

### DIFF
--- a/colorful/fields.py
+++ b/colorful/fields.py
@@ -5,7 +5,7 @@ from django.forms.fields import RegexField
 
 from widgets import ColorFieldWidget
 
-RGB_REGEX = re.compile('^#?((?:[0-F]{3}){1,2})$', re.IGNORECASE)
+RGB_REGEX = re.compile('^#?((?:[0-f]{3}){1,2})$', re.IGNORECASE)
 
 class RGBColorField(CharField):
 


### PR DESCRIPTION
django-parsley's regex matching is not case-insensitive, so the provided regex (caps) and the values that are inserted by the colorpicker (lowercase) cause client-side validation to fail.  This simple commit aims to fix this particular case without necessarily affecting anything else negatively.

Use it, don't use it... up to you :)
