### PR TITLE
Add possibility to leave colorfield blank

### DIFF
--- a/colorful/fields.py
+++ b/colorful/fields.py
@@ -18,6 +18,9 @@ class RGBColorField(CharField):
         kwargs['max_length'] = 7
         super(RGBColorField, self).__init__(*args, **kwargs)
 
+        if self.blank:
+            self.widget = widgets.NullableColorFieldWidget
+
     def formfield(self, **kwargs):
         kwargs.update({
             'form_class': forms.RGBColorField,

--- a/colorful/widgets.py
+++ b/colorful/widgets.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import json
 
-from django.forms.widgets import TextInput, MultiWidget, CheckboxInput
+from django.forms.widgets import CheckboxInput, MultiWidget, TextInput
 from django.utils.safestring import mark_safe
 
 

--- a/colorful/widgets.py
+++ b/colorful/widgets.py
@@ -41,13 +41,13 @@ class NullableColorFieldWidget(MultiWidget):
                 </script>
                 ''' % (color_id, checkbox_id)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         parts = []
         checkbox_id = "id_%s_0" % name
         color_id = "id_%s_1" % name
         if value:
             self.widgets[0].attrs['checked'] = ''
-        parts.append(super(NullableColorFieldWidget, self).render(name, value, attrs))
+        parts.append(super(NullableColorFieldWidget, self).render(name, value, attrs, renderer))
         parts.append(self.render_script(color_id, checkbox_id))
         return mark_safe(''.join(parts))
 

--- a/colorful/widgets.py
+++ b/colorful/widgets.py
@@ -88,7 +88,7 @@ class ColorFieldWidget(TextInput):
                 </script>
                 ''' % (id, json.dumps(options))
 
-    def render(self, name, value, attrs={}):
+    def render(self, name, value, renderer=None, attrs={}):
         parts = []
         if 'id' not in attrs:
             attrs['id'] = "id_%s" % name

--- a/colorful/widgets.py
+++ b/colorful/widgets.py
@@ -16,8 +16,8 @@ class NullableColorFieldWidget(MultiWidget):
 
     def decompress(self, value):
         if value:
-            return [True, value]
-        return [False, '']
+            return [False, value]
+        return [True, '']
 
     def value_from_datadict(self, data, files, name):
         blank = self.widgets[0].value_from_datadict(data, files, name + '_0')

--- a/colorful/widgets.py
+++ b/colorful/widgets.py
@@ -45,7 +45,8 @@ class NullableColorFieldWidget(MultiWidget):
         checkbox_id = "id_%s_0" % name
         color_id = "id_%s_1" % name
         if value:
-            self.widgets[0].attrs['checked'] = ''
+            del self.widgets[0].attrs['checked']
+
         parts.append(super(NullableColorFieldWidget, self).render(name, value, attrs, renderer))
         parts.append(self.render_script(color_id, checkbox_id))
         return mark_safe(''.join(parts))

--- a/colorful/widgets.py
+++ b/colorful/widgets.py
@@ -31,11 +31,10 @@ class NullableColorFieldWidget(MultiWidget):
     @staticmethod
     def render_script(color_id, checkbox_id):
         return '''
-                <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
                 <script type="text/javascript">
-                    $(document).ready(function() {
-                        $("#%s").on("click", function() {
-                            $("#%s").prop("checked", false);
+                    window.addEventListener('load', function() {
+                        document.getElementById('%s').addEventListener('click', function() {
+                            document.getElementById('%s').checked = false;
                         });
                     });
                 </script>

--- a/colorful/widgets.py
+++ b/colorful/widgets.py
@@ -2,8 +2,31 @@ from __future__ import unicode_literals
 
 import json
 
-from django.forms.widgets import TextInput
+from django.forms.widgets import TextInput, MultiWidget, CheckboxInput
 from django.utils.safestring import mark_safe
+
+
+class NullableColorFieldWidget(MultiWidget):
+    def __init__(self, colors=None, attrs=None):
+        _widgets = (
+            CheckboxInput(),
+            ColorFieldWidget(colors, attrs)
+        )
+        super(NullableColorFieldWidget, self).__init__(_widgets, attrs)
+
+    def decompress(self, value):
+        if value:
+            return [True, value]
+        return [False, '']
+
+    def value_from_datadict(self, data, files, name):
+        blank = self.widgets[0].value_from_datadict(data, files, name + '_0')
+        color = self.widgets[1].value_from_datadict(data, files, name + '_1')
+
+        if blank:
+            return None
+        else:
+            return color
 
 
 class ColorFieldWidget(TextInput):

--- a/colorful/widgets.py
+++ b/colorful/widgets.py
@@ -8,10 +8,10 @@ from django.utils.safestring import mark_safe
 
 class NullableColorFieldWidget(MultiWidget):
     def __init__(self, colors=None, attrs=None):
-        _widgets = (
-            CheckboxInput(),
+        _widgets = [
+            CheckboxInput(attrs={'checked': 'checked', 'style': 'display:none'}),
             ColorFieldWidget(colors, attrs)
-        )
+        ]
         super(NullableColorFieldWidget, self).__init__(_widgets, attrs)
 
     def decompress(self, value):
@@ -27,6 +27,29 @@ class NullableColorFieldWidget(MultiWidget):
             return None
         else:
             return color
+
+    @staticmethod
+    def render_script(color_id, checkbox_id):
+        return '''
+                <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+                <script type="text/javascript">
+                    $(document).ready(function() {
+                        $("#%s").on("click", function() {
+                            $("#%s").prop("checked", false);
+                        });
+                    });
+                </script>
+                ''' % (color_id, checkbox_id)
+
+    def render(self, name, value, attrs=None):
+        parts = []
+        checkbox_id = "id_%s_0" % name
+        color_id = "id_%s_1" % name
+        if value:
+            self.widgets[0].attrs['checked'] = ''
+        parts.append(super(NullableColorFieldWidget, self).render(name, value, attrs))
+        parts.append(self.render_script(color_id, checkbox_id))
+        return mark_safe(''.join(parts))
 
 
 class ColorFieldWidget(TextInput):

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -197,8 +197,9 @@ class TestNullableColorFieldWidget(SimpleTestCase):
             '<input type="checkbox" name="test_0" checked="checked" style="display:none" />',
             widget.render('test', None)
         )
+
         self.assertInHTML(
-            '<input name="test_1" type="color">',
+            '<input name="test_1" type="color" checked />',
             widget.render('test', None)
         )
 
@@ -216,9 +217,8 @@ class TestNullableColorFieldWidget(SimpleTestCase):
 
     def test_render_with_value(self):
         widget = NullableColorFieldWidget()
-
         self.assertInHTML(
-            '<input type="checkbox" name="test_0" style="display:none" checked />',
+            '<input type="checkbox" name="test_0" style="display:none" />',
             widget.render('test', '#FFFFFF')
         )
         self.assertInHTML(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -227,3 +227,16 @@ class TestNullableColorFieldWidget(SimpleTestCase):
             '<input type="color" name="test_1" value="#FFFFFF" />',
             widget.render('test', '#FFFFFF')
         )
+
+    def test_value_from_datadict(self):
+        widget = NullableColorFieldWidget()
+
+        self.assertEqual(
+            widget.value_from_datadict({'test_0': True, 'test_1': '#000000'}, {}, 'test'),
+            None
+        )
+
+        self.assertEqual(
+            widget.value_from_datadict({'test_0': False, 'test_1': '#FFFFFF'}, {}, 'test'),
+            '#FFFFFF'
+        )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -221,7 +221,9 @@ class TestNullableColorFieldWidget(SimpleTestCase):
             '<input type="checkbox" name="test_0" style="display:none" />',
             widget.render('test', '#FFFFFF')
         )
+
+        widget = NullableColorFieldWidget()
         self.assertInHTML(
-            '<input name="test_1" type="color" value="#FFFFFF">',
+            '<input type="color" name="test_1" value="#FFFFFF" />',
             widget.render('test', '#FFFFFF')
         )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -202,6 +202,18 @@ class TestNullableColorFieldWidget(SimpleTestCase):
             widget.render('test', None)
         )
 
+    def test_render_with_id(self):
+        widget = NullableColorFieldWidget()
+
+        self.assertInHTML(
+            '<input type="checkbox" name="test_0" checked="checked" id="id_color_0" style="display:none" />',
+            widget.render('test', None, {'id': 'id_color'})
+        )
+        self.assertInHTML(
+            '<input type="color" name="test_1" id="id_color_1" />',
+            widget.render('test', None, {'id': 'id_color'})
+        )
+
     def test_render_with_value(self):
         widget = NullableColorFieldWidget()
 


### PR DESCRIPTION
Hi,
First of all, thanks for a great extension! I enjoy it very much.
As I've noticed some others required as well (#28), I am looking for an option to leave the colorfield blank.

This is a first draft of a possible solution. If you can spare the time I would love to get some feedback.

For now the extra checkbox indicating whether a value has been set is not updated. I would like to hide this and set it to false when the color-input is clicked.