### PR TITLE
Correct CSS typo and add display property to fix IE11 rendering issue

### DIFF
--- a/colorful/static/colorful/colorPicker.css
+++ b/colorful/static/colorful/colorPicker.css
@@ -1,4 +1,5 @@
-v.colorPicker-picker {
+div.colorPicker-picker {
+    display: inline-block;
     height: 16px;
     width: 16px;
     padding: 0 !important;


### PR DESCRIPTION
Internet Explorer 11 doesn't support the color type input and makes use of the Really Simple Color Picker. However it doesn't display correctly due to a typo introduced in 68c54e49fcb6f785f4ef020e02495c9db18e2110 ('div' became 'v') and a lack of a display property.

**Prior to change**:
![ie11](https://cloud.githubusercontent.com/assets/26024306/23331360/6d8eb1c8-fbb4-11e6-8d8f-667a233c21c4.png)

**After change**:
![ie11_edited_css](https://cloud.githubusercontent.com/assets/26024306/23331420/b450eb7a-fbb5-11e6-8a29-2633f7a5a7c0.png)

